### PR TITLE
Add workflow permissions block to eip-sync.yml

### DIFF
--- a/.github/workflows/eip-sync.yml
+++ b/.github/workflows/eip-sync.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+  pull-requests: write
 name: Sync EIPs Repository
 on:
     schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/3webs-org/eip-info-website/security/code-scanning/2](https://github.com/3webs-org/eip-info-website/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or to the specific job(s) that require it. The block should grant only the permissions needed for the workflow to function. In this case, the workflow uses actions that create and update pull requests and synchronize submodules, which typically require `contents: write` and `pull-requests: write` permissions. The best practice is to add the `permissions` block at the top level of the workflow (applies to all jobs), unless different jobs require different permissions. The change should be made at the top of the file, after the `name` and before the `on` block, or at the job level if more granular control is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
